### PR TITLE
Update Repo URL

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -41,7 +41,7 @@ jobs:
         uses: docker/metadata-action@v4
         with:
           images: |
-            giswqs/whiteboxR
+            opengeos/whiteboxR
             ghcr.io/${{ github.repository }}
           tags: |
             latest

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -12,8 +12,8 @@ Encoding: UTF-8
 Language: en-US
 RoxygenNote: 7.2.3
 Roxygen: list(markdown = TRUE)
-URL: https://github.com/giswqs/whiteboxR
-BugReports: https://github.com/giswqs/whiteboxR/issues
+URL: https://github.com/opengeos/whiteboxR
+BugReports: https://github.com/opengeos/whiteboxR/issues
 Suggests: knitr, rmarkdown, testthat, terra, sf, raster
 VignetteBuilder: knitr
 Depends: R (>= 3.0.0)

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
 # Reference: https://aboland.ie/Docker.html
 # Build Steps:
 
-# docker build -t giswqs/whiteboxR .
+# docker build -t opengeos/whiteboxR .
 # docker push giswqs/whiteboxr:latest
-# docker run -d -p 8787:8787 -e PASSWORD=mypassword -v ~/Documents:/home/rstudio/ giswqs/whiteboxr
+# docker run -d -p 8787:8787 -e PASSWORD=mypassword -v ~/Documents:/home/rstudio/ opengeos/whiteboxr
 # Then open your web browser and navigate to `http://localhost:8787`. The default username is `rstudio` and the default password is `mypassword`.
 
 FROM rocker/rstudio:latest

--- a/NEWS.md
+++ b/NEWS.md
@@ -50,22 +50,22 @@
     
     * Remove several one and two character flag aliases from `argument_name` and replace with full name
     
- * Add support for showing warning messages in regular interactive/verbose mode, thanks to @alenahav for reporting an issue (https://github.com/giswqs/whiteboxR/issues/75) with `wbt_fd8_flow_accumulation()`
+ * Add support for showing warning messages in regular interactive/verbose mode, thanks to @alenahav for reporting an issue (https://github.com/opengeos/whiteboxR/issues/75) with `wbt_fd8_flow_accumulation()`
  
- * Functions that take multiple files are auto-quoted by default; thanks to François-Nicolas Robinne for reporting issue (@FNRobinne; https://github.com/giswqs/whiteboxR/issues/55) with `wbt_mosaic()`
+ * Functions that take multiple files are auto-quoted by default; thanks to François-Nicolas Robinne for reporting issue (@FNRobinne; https://github.com/opengeos/whiteboxR/issues/55) with `wbt_mosaic()`
  
- * Error output is now more verbose, ensuring relevant tool output is displayed to user on error regardless of verbosity, platform, etc. Thanks to Jeffrey W. Rozelle for reporting issue (@jwilliamrozelle; https://github.com/giswqs/whiteboxR/issues/80) with getting error messages about unsupported raster types
+ * Error output is now more verbose, ensuring relevant tool output is displayed to user on error regardless of verbosity, platform, etc. Thanks to Jeffrey W. Rozelle for reporting issue (@jwilliamrozelle; https://github.com/opengeos/whiteboxR/issues/80) with getting error messages about unsupported raster types
  
 
 # whitebox 2.1.3
 
  * Generated `whitebox_tools` commands no longer include flags for default arguments that are stored in settings.json unless specified by the user.
  
-   * Updates to fix issues with permissions to write _settings.json_; thanks to Henrik (@hewag1975) for reporting problems on Shiny Server (https://github.com/giswqs/whiteboxR/issues/67)
+   * Updates to fix issues with permissions to write _settings.json_; thanks to Henrik (@hewag1975) for reporting problems on Shiny Server (https://github.com/opengeos/whiteboxR/issues/67)
  
- * `wbt_install()` / `install_whitebox()` now removes the downloaded zip file on exit thanks to Christoph Stepper (@cstepper; https://github.com/giswqs/whiteboxR/issues/72)
+ * `wbt_install()` / `install_whitebox()` now removes the downloaded zip file on exit thanks to Christoph Stepper (@cstepper; https://github.com/opengeos/whiteboxR/issues/72)
  
- * New default arguments for `wbt_list_tools()`, `wbt_time_in_daylight()`, `wbt_shadow_image()` thanks to Jens Wiesehahn (@wiesehahn; https://github.com/giswqs/whiteboxR/issues/70, https://github.com/giswqs/whiteboxR/issues/73)
+ * New default arguments for `wbt_list_tools()`, `wbt_time_in_daylight()`, `wbt_shadow_image()` thanks to Jens Wiesehahn (@wiesehahn; https://github.com/opengeos/whiteboxR/issues/70, https://github.com/opengeos/whiteboxR/issues/73)
  
 # whitebox 2.1.2
 
@@ -73,7 +73,7 @@
  
 # whitebox 2.1.1
 
- * File path arguments to tools now automatically perform path expansion (converting `~` to your home directory with `path.expand()`). This also works on arguments that contain comma or semicolon delimited lists. (https://github.com/giswqs/whiteboxR/issues/62)
+ * File path arguments to tools now automatically perform path expansion (converting `~` to your home directory with `path.expand()`). This also works on arguments that contain comma or semicolon delimited lists. (https://github.com/opengeos/whiteboxR/issues/62)
  
  * Corrections to `wbttoolparameters` dataset (updated classification of input/output parameters) 
  

--- a/PY2R/automation.py
+++ b/PY2R/automation.py
@@ -8,7 +8,7 @@
 # Step 6 - Update version number and RoxygenNote in DESCRIPTION
 # Step 7 - Open whiteboxR.Rproj in RStudio and run build_check.R
 # Step 8 - Commit and push changes
-# Step 9 - Test installation from GitHub: devtools::install_github("giswqs/whiteboxR@develop")
+# Step 9 - Test installation from GitHub: devtools::install_github("opengeos/whiteboxR@develop")
 # Step 10 - Merge pull request on GitHub
 # Step 11 - Switch to master branch and pull updates: git checkout master | git pull
 # Step 12 - Create R package: RStudio - Build - Build Source Package

--- a/PY2R/build_check.R
+++ b/PY2R/build_check.R
@@ -21,5 +21,5 @@ devtools::check()
 pkgdown::build_site()
 # devtools::submit_cran()
 
-devtools::install_github("giswqs/whiteboxR")
-devtools::install_github("giswqs/whiteboxR@develop")
+devtools::install_github("opengeos/whiteboxR")
+devtools::install_github("opengeos/whiteboxR@develop")

--- a/R/wbt.R
+++ b/R/wbt.R
@@ -1145,7 +1145,7 @@ sample_dem_data <- function(destfile = file.path(system.file('extdata', package=
     }
   }
   if (fp == "") {
-    try(download.file("https://github.com/giswqs/whiteboxR/raw/master/inst/extdata/DEM.tif",
+    try(download.file("https://github.com/opengeos/whiteboxR/raw/master/inst/extdata/DEM.tif",
                       destfile = destfile,
                       mode = "wb", ...))
     if (missing(destfile)) {

--- a/README.Rmd
+++ b/README.Rmd
@@ -19,10 +19,9 @@ knitr::opts_chunk$set(
 [![CRAN download count](https://cranlogs.r-pkg.org/badges/grand-total/whitebox)](https://cranlogs.r-pkg.org/badges/grand-total/whitebox)
 [![whitebox Manual](https://img.shields.io/badge/docs-HTML-informational)](https://whiteboxR.gishub.org/reference/index.html)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/license/MIT/)
-[![R-CMD-check](https://github.com/giswqs/whiteboxR/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/giswqs/whiteboxR/actions/workflows/R-CMD-check.yaml)
-[![codecov](https://codecov.io/gh/giswqs/whiteboxR/branch/master/graph/badge.svg)](https://app.codecov.io/gh/giswqs/whiteboxR)
+[![R-CMD-check](https://github.com/opengeos/whiteboxR/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/opengeos/whiteboxR/actions/workflows/R-CMD-check.yaml)
+[![codecov](https://codecov.io/gh/opengeos/whiteboxR/branch/master/graph/badge.svg)](https://app.codecov.io/gh/opengeos/whiteboxR)
 [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/brownag/whitebox-r-binder/master?urlpath=rstudio)
-[![Twitter Follow](https://img.shields.io/twitter/follow/giswqs?style=social)](https://twitter.com/giswqs)
 [![Donate](https://img.shields.io/badge/Donate-Buy%20me%20a%20coffee-yellowgreen.svg)](https://www.buymeacoffee.com/giswqs)
 <!-- badges: end -->
 
@@ -30,11 +29,11 @@ knitr::opts_chunk$set(
 
 This repository is related to the **whitebox** R package for geospatial analysis, which is an R frontend of a stand-alone executable command-line program called **[WhiteboxTools](https://github.com/jblindsay/whitebox-tools)**. 
 
-* Authors: Dr. John Lindsay (<https://jblindsay.github.io/ghrg/index.html>)
+* Authors: John Lindsay (<https://jblindsay.github.io/ghrg/index.html>)
 * Contributors: 
-    * Dr. Qiusheng Wu (<https://wetlands.io> | <https://blog.gishub.org>)
+    * Qiusheng Wu (<https://wetlands.io>)
     * Andrew G. Brown (<https://humus.rocks>)
-* GitHub repo: <https://github.com/giswqs/whiteboxR>
+* GitHub repo: <https://github.com/opengeos/whiteboxR>
 * CRAN link: <https://cran.r-project.org/package=whitebox>
 * WhiteboxTools: <https://github.com/jblindsay/whitebox-tools>
 * User Manual: <https://jblindsay.github.io/wbt_book/>
@@ -69,11 +68,11 @@ install.packages("whitebox")
 
 ### 2. GitHub
 
-You can alternatively install the development version of **whitebox** from [GitHub](https://github.com/giswqs/whiteboxR) as follows:
+You can alternatively install the development version of **whitebox** from [GitHub](https://github.com/opengeos/whiteboxR) as follows:
 
 ```R
 if (!require("remotes")) install.packages('remotes')
-remotes::install_github("giswqs/whiteboxR", build = FALSE)
+remotes::install_github("opengeos/whiteboxR", build = FALSE)
 ```
 
 ## Usage
@@ -226,7 +225,7 @@ If you are interested in using the 'WhiteboxTools' command-line program, check [
 
 If you would like to contribute to the project as a developer, follow these instructions to get started:
 
-1. Fork the whiteboxR repository (<https://github.com/giswqs/whiteboxR>)
+1. Fork the whiteboxR repository (<https://github.com/opengeos/whiteboxR>)
 2. Create your feature branch (git checkout -b my-new-feature)
 3. Commit your changes (git commit -am 'Add some feature')
 4. Push to the branch (git push origin my-new-feature)
@@ -242,7 +241,7 @@ The whitebox **R** package is distributed under the [MIT license](https://openso
 
 ## Reporting Bugs
 
-whitebox is distributed as is and without warranty of suitability for application. If you encounter flaws with the software (i.e. bugs) please report the issue. Providing a detailed description of the conditions under which the bug occurred will help to identify the bug. *Use the [Issues tracker](https://github.com/giswqs/whiteboxR/issues) on GitHub to report issues with the software and to request feature enchancements.* Please do not email Dr. Lindsay directly with bugs.
+whitebox is distributed as is and without warranty of suitability for application. If you encounter flaws with the software (i.e. bugs) please report the issue. Providing a detailed description of the conditions under which the bug occurred will help to identify the bug. *Use the [Issues tracker](https://github.com/opengeos/whiteboxR/issues) on GitHub to report issues with the software and to request feature enchancements.* Please do not email Dr. Lindsay directly with bugs.
 
 
 ```{r, echo = FALSE}

--- a/README.md
+++ b/README.md
@@ -9,11 +9,9 @@ count](https://cranlogs.r-pkg.org/badges/grand-total/whitebox)](https://cranlogs
 Manual](https://img.shields.io/badge/docs-HTML-informational)](https://whiteboxR.gishub.org/reference/index.html)
 [![License:
 MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/license/MIT/)
-[![R-CMD-check](https://github.com/giswqs/whiteboxR/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/giswqs/whiteboxR/actions/workflows/R-CMD-check.yaml)
-[![codecov](https://codecov.io/gh/giswqs/whiteboxR/branch/master/graph/badge.svg)](https://app.codecov.io/gh/giswqs/whiteboxR)
+[![R-CMD-check](https://github.com/opengeos/whiteboxR/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/opengeos/whiteboxR/actions/workflows/R-CMD-check.yaml)
+[![codecov](https://codecov.io/gh/opengeos/whiteboxR/branch/master/graph/badge.svg)](https://app.codecov.io/gh/opengeos/whiteboxR)
 [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/brownag/whitebox-r-binder/master?urlpath=rstudio)
-[![Twitter
-Follow](https://img.shields.io/twitter/follow/giswqs?style=social)](https://twitter.com/giswqs)
 [![Donate](https://img.shields.io/badge/Donate-Buy%20me%20a%20coffee-yellowgreen.svg)](https://www.buymeacoffee.com/giswqs)
 <!-- badges: end -->
 
@@ -24,13 +22,12 @@ analysis, which is an R frontend of a stand-alone executable
 command-line program called
 **[WhiteboxTools](https://github.com/jblindsay/whitebox-tools)**.
 
--   Authors: Dr. John Lindsay
+-   Authors: John Lindsay
     (<https://jblindsay.github.io/ghrg/index.html>)
 -   Contributors:
-    -   Dr. Qiusheng Wu (<https://wetlands.io> |
-        <https://blog.gishub.org>)
+    -   Qiusheng Wu (<https://wetlands.io>)
     -   Andrew G. Brown (<https://humus.rocks>)
--   GitHub repo: <https://github.com/giswqs/whiteboxR>
+-   GitHub repo: <https://github.com/opengeos/whiteboxR>
 -   CRAN link: <https://cran.r-project.org/package=whitebox>
 -   WhiteboxTools: <https://github.com/jblindsay/whitebox-tools>
 -   User Manual: <https://jblindsay.github.io/wbt_book/>
@@ -97,10 +94,10 @@ it with:
 ### 2. GitHub
 
 You can alternatively install the development version of **whitebox**
-from [GitHub](https://github.com/giswqs/whiteboxR) as follows:
+from [GitHub](https://github.com/opengeos/whiteboxR) as follows:
 
     if (!require("remotes")) install.packages('remotes')
-    remotes::install_github("giswqs/whiteboxR", build = FALSE)
+    remotes::install_github("opengeos/whiteboxR", build = FALSE)
 
 ### 3. Docker
 
@@ -404,7 +401,7 @@ If you would like to contribute to the project as a developer, follow
 these instructions to get started:
 
 1.  Fork the whiteboxR repository
-    (<https://github.com/giswqs/whiteboxR>)
+    (<https://github.com/opengeos/whiteboxR>)
 2.  Create your feature branch (git checkout -b my-new-feature)
 3.  Commit your changes (git commit -am ‘Add some feature’)
 4.  Push to the branch (git push origin my-new-feature)
@@ -427,6 +424,6 @@ whitebox is distributed as is and without warranty of suitability for
 application. If you encounter flaws with the software (i.e. bugs) please
 report the issue. Providing a detailed description of the conditions
 under which the bug occurred will help to identify the bug. *Use the
-[Issues tracker](https://github.com/giswqs/whiteboxR/issues) on GitHub
+[Issues tracker](https://github.com/opengeos/whiteboxR/issues) on GitHub
 to report issues with the software and to request feature
 enchancements.* Please do not email Dr. Lindsay directly with bugs.

--- a/data-raw/wbttools2.R
+++ b/data-raw/wbttools2.R
@@ -2,7 +2,7 @@ library(reticulate)
 library(jsonlite)
 library(data.table)
 
-# assumes clone of https://github.com/giswqs/whiteboxgui in parent dir
+# assumes clone of https://github.com/opengeos/whiteboxgui in parent dir
 py_run_file("../whiteboxgui/whiteboxgui/whiteboxgui.py")
 py_run_string("with open('data-raw/whitebox_tools.json', 'w') as outfile:\n
                  json.dump(get_wbt_dict(reset = True), outfile)")
@@ -10,7 +10,7 @@ py_run_string("with open('data-raw/whitebox_ext.json', 'w') as outfile:\n
                  json.dump(get_ext_dict(reset = True), outfile)")
 
 ## get open core tool info
-# whitebox_json <- jsonlite::read_json("https://raw.githubusercontent.com/giswqs/whiteboxgui/master/whiteboxgui/data/whitebox_tools.json", simplifyVector = TRUE)
+# whitebox_json <- jsonlite::read_json("https://raw.githubusercontent.com/opengeos/whiteboxgui/master/whiteboxgui/data/whitebox_tools.json", simplifyVector = TRUE)
 whitebox_json <- read_json("data-raw/whitebox_tools.json")
 wbttools <- rbindlist(lapply(whitebox_json, function(x) as.data.frame(x[1:7])))
 colnames(wbttools)[1:3] <- c("tool_name", "function_name", "toolbox_name")


### PR DESCRIPTION
This PR updates all the repo url from giswqs to opengeos. If you cloned the repo previously, it is recommended that you update the Git repo remote URL as follows.

```bash
git remote set-url origin https://github.com/opengeos/whiteboxR.git
```