### PR TITLE
`wbt_wd()`: fix behavior and message for `wd=""`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,8 @@
  
  * Add `wbt_runner_path()` (analog of `wbt_exe_path()` for `whitebox_runner` GUI executable) and `wbt_launch_runner()` a simple function to launch the GUI.
  
+ * `wbt_wd("")` now sets the value of `working_directory` in the WhiteboxTools settings.json file to `""` and triggers background options to prevent `--wd` flag being added until a new working directory is set. This has been a long-standing issue, resolved following <https://github.com/opengeos/whiteboxR/issues/108>.
+ 
 # whitebox 2.3.0
 
  * Updates for WhiteboxTools v2.3.0 (https://github.com/jblindsay/whitebox-tools/releases/tag/v2.3.0)

--- a/R/wbt.R
+++ b/R/wbt.R
@@ -40,8 +40,9 @@ wbt_init <- function(exe_path = wbt_exe_path(shell_quote = FALSE),
       !is.null(wd) ||
       !is.null(verbose) ||
       !is.null(compress_rasters)) {
-    if (!length(wd) > 0 && wd == "") {
-      .wbt_wd_unset("")
+    
+    if (!is.null(wd) && length(wd) > 0 && (is.na(wd) || wd == "")) {
+      .wbt_wd_unset()
     }
     
     # set the path with wbt_options

--- a/R/wbt.R
+++ b/R/wbt.R
@@ -341,7 +341,14 @@ wbt_wd <- function(wd = NULL) {
 }
 
 .wbt_wd_unset <- function() {
-  try(wbt_system_call(paste0("--wd=", shQuote(""))), silent = TRUE)
+  # this doesnt actually set the value ""
+  #  - try(wbt_system_call(paste0("--wd=", shQuote(""))), silent = TRUE)
+  try({
+    f <- file.path(dirname(wbt_exe_path(shell_quote = FALSE)), "settings.json")
+    x <- readLines(f, warn = FALSE)
+    x[grepl('^ *"working_directory": .*$', x)] <- '  "working_directory": "",'
+    writeLines(x, f)
+  })
 }
 
 #' @description `wbt_verbose()`: Check verbose options for 'WhiteboxTools'

--- a/R/wbt.R
+++ b/R/wbt.R
@@ -617,10 +617,7 @@ wbt_install <- function(pkg_dir = wbt_data_dir(), platform = NULL, force = FALSE
       cat("    wbt_version()\n")
 
       # call wbt_init (sets package option)
-      wbt_init(exe_path = exe_path_out)
-      
-      # unset any working directory that may be set in settings.json
-      .wbt_wd_unset()
+      wbt_init(exe_path = exe_path_out, wd = "")
     }
 
   } else if (!force) {

--- a/R/wbt.R
+++ b/R/wbt.R
@@ -40,6 +40,10 @@ wbt_init <- function(exe_path = wbt_exe_path(shell_quote = FALSE),
       !is.null(wd) ||
       !is.null(verbose) ||
       !is.null(compress_rasters)) {
+    if (!length(wd) > 0 && wd == "") {
+      .wbt_wd_unset("")
+    }
+    
     # set the path with wbt_options
     wbt_options(exe_path = exe_path, ...)
   }
@@ -288,7 +292,7 @@ wbt_data_dir <- function() {
 #'
 #' @return `wbt_wd()`: character; when working directory is unset, will not add `--wd=` arguments to calls and should be the same as using `getwd()`. See Details.
 #'
-#' @details `wbt_wd()`: Before you set the working directory in a session the default output will be in your current R working directory unless otherwise specified. You can change working directory at any time by setting the `wd` argument to `wbt_wd()` and running a tool. Note that once you have set a working directory, the directory needs to be set somewhere to "replace" the old value; just dropping the flag will not change the working directory back to the R working directory. To "unset" the option in the R package you can use `wbt_wd("")` which is equivalent to `wbt_wd(getwd())`.
+#' @details `wbt_wd()`: Before you set the working directory in a session the default output will be in your current R working directory unless otherwise specified. You can change working directory at any time by setting the `wd` argument to `wbt_wd()` and running a tool. Note that once you have set a working directory, the directory needs to be set somewhere to "replace" the old value; just dropping the flag will not change the working directory back to the R working directory. To "unset" the option in the R package you can use `wbt_wd("")` which removes the `--wd` flag from commands and sets the `working_directory` value in the WhiteboxTools _settings.json_ to `""`.
 #' @rdname wbt_init
 #' @export
 #' @keywords General
@@ -296,28 +300,17 @@ wbt_data_dir <- function() {
 #' \dontrun{
 #'
 #' ## wbt_wd():
-#'
+#' 
+#' # no working directory set
+#' wbt_wd(wd = "")
+#' 
 #' # set WBT working directory to R working directory
 #' wbt_wd(wd = getwd())
 #' }
 wbt_wd <- function(wd = NULL) {
 
-  # system environment var takes precedence
-  syswd <- Sys.getenv("R_WHITEBOX_WD")
-  if (nchar(syswd) > 0 && dir.exists(syswd)) {
-    return(syswd)
-  }
-
   if (length(wd) > 0 && (is.na(wd) || wd == "")) {
-    curwd <- getwd()
-    if(wbt_verbose()) {
-      cat("Reset WhiteboxTools working directory to current R working directory:", curwd)
-    }
-    try(wbt_system_call(paste0("--wd=", curwd)), silent = TRUE)
-    if (wbt_verbose()) {
-      cat("Unset WhiteboxTools working directory flag `whitebox.wd` / `--wd`\n")
-    }
-    wd <- "" #structure(curwd, unset = TRUE)
+    .wbt_wd_unset()
   }
 
   if (is.character(wd)) {
@@ -325,6 +318,12 @@ wbt_wd <- function(wd = NULL) {
     wbt_options(wd = wd)
   }
 
+  # system environment var takes precedence
+  syswd <- Sys.getenv("R_WHITEBOX_WD")
+  if (nchar(syswd) > 0 && dir.exists(syswd)) {
+    return(syswd)
+  }
+  
   # package option checked next; if missing default is getwd() (unspecified should be same as getwd())
   res <- getOption("whitebox.wd")
 
@@ -333,11 +332,15 @@ wbt_wd <- function(wd = NULL) {
     res <- ""
   # otherwise, if the option is invalid directory message
   } else if (!is.null(res) && !dir.exists(res)) {
-    message("Invalid path for `whitebox.wd`: directory does not exist.\nDefaulting to current R working directory: ", getwd())
-    res <- getwd()
+    message("Invalid path for `whitebox.wd`: directory does not exist.\nDefaulting to \"\"")
+    res <- ""
   }
 
   invisible(res)
+}
+
+.wbt_wd_unset <- function() {
+  try(wbt_system_call(paste0("--wd=", shQuote(""))), silent = TRUE)
 }
 
 #' @description `wbt_verbose()`: Check verbose options for 'WhiteboxTools'
@@ -581,8 +584,9 @@ wbt_install <- function(pkg_dir = wbt_data_dir(), platform = NULL, force = FALSE
     }
     res <- -1
     for (method in c(if (os == "Windows") "internal", "libcurl", "auto")) {
-      if (!inherits(try(res <- utils::download.file(url, exe_zip, method = method), silent = TRUE),
-                    "try-error") && res == 0)
+      if (!inherits(try({
+        res <- utils::download.file(url, exe_zip, method = method)
+      }, silent = TRUE), "try-error") && res == 0)
         break
     }
 
@@ -613,6 +617,9 @@ wbt_install <- function(pkg_dir = wbt_data_dir(), platform = NULL, force = FALSE
 
       # call wbt_init (sets package option)
       wbt_init(exe_path = exe_path_out)
+      
+      # unset any working directory that may be set in settings.json
+      .wbt_wd_unset()
     }
 
   } else if (!force) {

--- a/man/wbt_init.Rd
+++ b/man/wbt_init.Rd
@@ -35,7 +35,7 @@ wbt_default_path()
 
 wbt_data_dir()
 
-wbt_wd(wd = NULL)
+wbt_wd(wd = NULL, verbose = wbt_verbose())
 
 wbt_verbose(verbose = NULL)
 
@@ -112,7 +112,7 @@ Returns the file path of 'WhiteboxTools' executable.
 
 \code{wbt_data_dir()}: Uses platform-specific user data directory from \code{tools::R_user_dir(package = "whitebox", which = "data")} on R 4.0+. On R<4 returns the original default \code{find.package("whitebox")}.
 
-\code{wbt_wd()}: Before you set the working directory in a session the default output will be in your current R working directory unless otherwise specified. You can change working directory at any time by setting the \code{wd} argument to \code{wbt_wd()} and running a tool. Note that once you have set a working directory, the directory needs to be set somewhere to "replace" the old value; just dropping the flag will not change the working directory back to the R working directory. To "unset" the option in the R package you can use \code{wbt_wd("")} which is equivalent to \code{wbt_wd(getwd())}.
+\code{wbt_wd()}: Before you set the working directory in a session the default output will be in your current R working directory unless otherwise specified. You can change working directory at any time by setting the \code{wd} argument to \code{wbt_wd()} and running a tool. Note that once you have set a working directory, the directory needs to be set somewhere to "replace" the old value; just dropping the flag will not change the working directory back to the R working directory. To "unset" the option in the R package you can use \code{wbt_wd("")} which removes the \code{--wd} flag from commands and sets the \code{working_directory} value in the WhiteboxTools \emph{settings.json} to \code{""}.
 }
 \examples{
 \dontrun{
@@ -135,6 +135,9 @@ wbt_exe_path()
 \dontrun{
 
 ## wbt_wd():
+
+# no working directory set
+wbt_wd(wd = "")
 
 # set WBT working directory to R working directory
 wbt_wd(wd = getwd())

--- a/man/wbt_init.Rd
+++ b/man/wbt_init.Rd
@@ -35,7 +35,7 @@ wbt_default_path()
 
 wbt_data_dir()
 
-wbt_wd(wd = NULL, verbose = wbt_verbose())
+wbt_wd(wd = NULL)
 
 wbt_verbose(verbose = NULL)
 

--- a/tests/testthat/test-wbt.R
+++ b/tests/testthat/test-wbt.R
@@ -108,8 +108,8 @@ test_that("wbt setting and using working directories", {
   expect_length(list.files(pattern = basename(tf)), 0)
   expect_length(list.files(path = mywd, pattern = basename(tf)), 1)
 
-  # NA or "" are converted to getwd() with an attribute set to remove the flag after next
-  expect_equal(wbt_wd(NA), "")
+  # "" resets wd flag and returns ""
+  expect_equal(wbt_wd(""), "")
 
   # cleanup
   unlink(tf)
@@ -203,6 +203,8 @@ test_that("wbt raster compression (requires WhiteboxTools v2.1.0 or higher)", {
 
   skip_if(dem == "")
 
+  wbt_wd(getwd())
+  
   wbt_geomorphons(sample_dem_data(), output = "test_compressed.tif", compress_rasters = TRUE)
 
   wbt_geomorphons(sample_dem_data(), output = "test_no-compress.tif", compress_rasters = FALSE)


### PR DESCRIPTION
 - RE: #108
   - On fresh install, pre-existing `settings.json` `working_directory` in the new install directory is set to `""`
   - `wbt_wd("")` now properly resets the `working_directory` setting and `--wd` flag under various conditions