### PR TITLE
wbt_file_path: add support for terra objects that have a file source

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # whitebox 2.3.4
 
- * Exported `wbt_file_path()`, a function previously used internally for creating safe, expanded, quoted, paths for building WhiteboxTools commands. 
+ * Exported `wbt_file_path()`, a function previously used internally for creating safe, expanded, quoted, paths for building WhiteboxTools commands. This function also supports the input of `terra` objects that are backed by file sources supported by WhiteboxTools.
 
 # whitebox 2.3.3
 

--- a/man/wbt_file_path.Rd
+++ b/man/wbt_file_path.Rd
@@ -7,7 +7,7 @@
 wbt_file_path(x, shell_quote = TRUE, delimiter = ",", check_exists = FALSE)
 }
 \arguments{
-\item{x}{character. Vector of file paths or strings of file paths for passing as arguments to WhiteboxTools.}
+\item{x}{character or \code{terra} object. Vector of file paths or strings of file paths for passing as arguments to WhiteboxTools. If the object is of class \code{SpatRaster}, \code{SpatRasterCollection}, \code{SpatVector} or \code{SpatVectorProxy} the sources are extracted with \code{terra::sources()}}
 
 \item{shell_quote}{logical. Shell quotes around result? Default: \code{TRUE}}
 


### PR DESCRIPTION
wbt_file_path: add support for terra objects that have a file source for raster and vector inputs

 - for #119